### PR TITLE
Fixing locale bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 duedil/secrets.py
 *.pyc
 *egg*
+.coverage
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 duedil/secrets.py
+*.pyc
+*egg*

--- a/duedil/v3pro.py
+++ b/duedil/v3pro.py
@@ -201,8 +201,7 @@ class Director(_EndPoint):
             results = self._get('service-addresses')
             address_list = []
             for r in results['response']['data']:
-                if not r.get('locale'):
-                    r['locale'] = self.locale
+                r['locale'] = r.get('locale', self.locale)
                 address_list.append(
                     ServiceAddress(self.api_key,
                                    sandbox=self.sandbox,
@@ -219,8 +218,7 @@ class Director(_EndPoint):
             results = self._get('companies')
             company_list = []
             for r in results['response']['data']:
-                if not r.get('locale'):
-                    r['locale'] = self.locale
+                r['locale'] = r.get('locale', self.locale)
                 company_list.append(
                     Company(self.api_key,
                             sandbox=self.sandbox, **r)
@@ -276,8 +274,7 @@ class Company(_EndPoint):
             results = self._get('directors')
             director_list = []
             for r in results['response']['data']:
-                if not r.get('locale'):
-                    r['locale'] = self.locale
+                r['locale'] = r.get('locale', self.locale)
                 director_list.append(
                     Director(self.api_key,
                              sandbox=self.sandbox, **r)
@@ -323,8 +320,7 @@ class Company(_EndPoint):
             results = self._get('directorships')
             directorships_list = []
             for r in results['response']['data']:
-                if not r.get('locale'):
-                    r['locale'] = self.locale
+                r['locale'] = r.get('locale', self.locale)
                 directorships_list.append(
                     DirectorShip(self.api_key,
                                  sandbox=self.sandbox, **r)
@@ -341,8 +337,7 @@ class Company(_EndPoint):
             try:
                 results = self._get('subsidiaries')
                 for r in results['response']['data']:
-                    if not r.get('locale'):
-                        r['locale'] = self.locale
+                    r['locale'] = r.get('locale', self.locale)
                     subsidiaries_list.append(
                         Company(self.api_key,
                                 sandbox=self.sandbox, **r)
@@ -363,8 +358,7 @@ class Company(_EndPoint):
             try:
                 results = self._get('parent')
                 p_data = results['response']
-                if not p_data.get('locale'):
-                    p_data['locale'] = self.locale
+                p_data['locale'] = p_data.get('locale', self.locale)
                 self._parent = Company(self.api_key,
                                        sandbox=self.sandbox, **p_data)
                 self._has_parent = True

--- a/duedil/v3pro.py
+++ b/duedil/v3pro.py
@@ -201,9 +201,10 @@ class Director(_EndPoint):
             results = self._get('service-addresses')
             address_list = []
             for r in results['response']['data']:
+                if not r.get('locale'):
+                    r['locale'] = self.locale
                 address_list.append(
                     ServiceAddress(self.api_key,
-                                   locale=self.locale,
                                    sandbox=self.sandbox,
                                    **r)
                 )
@@ -218,8 +219,10 @@ class Director(_EndPoint):
             results = self._get('companies')
             company_list = []
             for r in results['response']['data']:
+                if not r.get('locale'):
+                    r['locale'] = self.locale
                 company_list.append(
-                    Company(self.api_key, locale=self.locale,
+                    Company(self.api_key,
                             sandbox=self.sandbox, **r)
                 )
             self._companies = company_list
@@ -233,8 +236,10 @@ class Director(_EndPoint):
             results = self._get('directorships')
             directorships_list = []
             for r in results['response']['data']:
+                if not r.get('locale'):
+                    r['locale'] = self.locale
                 directorships_list.append(
-                    DirectorShip(self.api_key, locale=self.locale,
+                    DirectorShip(self.api_key,
                                  sandbox=self.sandbox, **r)
                 )
             self._directorships = directorships_list
@@ -271,8 +276,10 @@ class Company(_EndPoint):
             results = self._get('directors')
             director_list = []
             for r in results['response']['data']:
+                if not r.get('locale'):
+                    r['locale'] = self.locale
                 director_list.append(
-                    Director(self.api_key, locale=self.locale,
+                    Director(self.api_key,
                              sandbox=self.sandbox, **r)
                 )
             self._directors = director_list
@@ -316,8 +323,10 @@ class Company(_EndPoint):
             results = self._get('directorships')
             directorships_list = []
             for r in results['response']['data']:
+                if not r.get('locale'):
+                    r['locale'] = self.locale
                 directorships_list.append(
-                    DirectorShip(self.api_key, locale=self.locale,
+                    DirectorShip(self.api_key,
                                  sandbox=self.sandbox, **r)
                 )
             self._directorships = directorships_list
@@ -332,8 +341,10 @@ class Company(_EndPoint):
             try:
                 results = self._get('subsidiaries')
                 for r in results['response']['data']:
+                    if not r.get('locale'):
+                        r['locale'] = self.locale
                     subsidiaries_list.append(
-                        Company(self.api_key, locale=self.locale,
+                        Company(self.api_key,
                                 sandbox=self.sandbox, **r)
                     )
             except HTTPError as e:
@@ -352,7 +363,9 @@ class Company(_EndPoint):
             try:
                 results = self._get('parent')
                 p_data = results['response']
-                self._parent = Company(self.api_key, locale=self.locale,
+                if not p_data.get('locale'):
+                    p_data['locale'] = self.locale
+                self._parent = Company(self.api_key,
                                        sandbox=self.sandbox, **p_data)
                 self._has_parent = True
             except HTTPError as e:


### PR DESCRIPTION
`locale` is already in the results usually, so setting always explicitly setting it was throwing an exception for having double `kwargs`. Tests pass now.